### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
### Descripción
Este pull request actualiza el archivo `.gitignore` para incluir las siguientes extensiones:

- `*.bak`: Archivos de respaldo generados por editores o herramientas
- `*.sqlite3`: Archivos de base de datos de SQLite, que no deberían ser versionados

### Motivo
Estos archivos son generados localmente durante el desarrollo y no deberían incluirse en el repositorio para evitar conflictos y mantener limpio el historial de commits.

### Notas
No afecta la lógica del proyecto, solo mejora el control de versiones.
